### PR TITLE
Composer instead of PEAR + test_directory grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,12 @@ While no longer actively supported, v1.x can be found on its [own branch](https:
 ## Installation
 
 1. Download and extract (or git clone) the project to a web-accessible directory.
-2. Change the permissions of `app/resource/cache` to `777`.
+2. Change the permissions of `app/resource/cache` to `777` or give the Apache user write access another way.
+3. If you have not already installed PHPUnit via Composer, do so using the following command:
+	1. cd /path/to/VisualPHPUnit/../
+	2. composer require phpunit/phpunit
 3. Open `app/config/bootstrap.php` with your favorite editor.
-    1. Within the `$config` array, change `pear_path` so that it points to the directory where PEAR is located.
+    1. Within the `$config` array, change `composer_vendor_path` so that it points to the Composer vendor directory where PHPUnit is located (if installed with the above step, this shouldn't need to be edited)
     2. Within the `$config` array, change the contents of `test_directories` to reflect the location(s) of your unit tests. Note that each directory acts as a root directory.
 4. Configure your web server (see below).
 
@@ -97,6 +100,14 @@ When that's done, restart your web server, and then point your browser at the se
 ## Project Configuration (optional)
 
 VPU comes with many of its features disabled by default.  In order to take advantage of them, you'll have to modify a few more lines in `app/config/bootstrap.php`.
+
+## Using VisualPHPUnit with Laravel
+
+It's simple to use VisualPHPUnit with Laravel. Assuming you have successfully installed with the above instructions, and the sample tests run, you need only do the following:
+
+1. In `app/config/bootstrap.php` add the path to your Laravel project's tests directory to the `test_directories` array (eg: '/var/www/laravel/tests')
+2. In `app/config/bootstrap.php` add your Laravel project's autoload.php to the `bootstraps` array (eg: '/var/www/laravel/bootstrap/autoload.php')
+3. Now reload VisualPHPUnit and run the tests from your Laravel project.
 
 ### <a name='graph-generation'></a>Graph Generation
 

--- a/app/config/bootstrap.php
+++ b/app/config/bootstrap.php
@@ -10,7 +10,8 @@ $config = array(
 
     // The directories where the tests reside
     'test_directories' => array(
-        "{$root}/app/test",
+        'Sample Tests' => "{$root}/app/test",
+        //'My Project' => '/var/www/sites/my.awesome.site.com/laravel/tests',
     ),
 
 
@@ -73,8 +74,8 @@ $config = array(
 
     // Paths to any necessary bootstraps
     'bootstraps' => array(
-        // '/path/to/bootstrap.php'
-        
+        // '/path/to/bootstrap.php',
+        //'/var/www/sites/my.awesome.site.com/laravel/bootstrap/autoload.php',
     )
 );
 

--- a/app/config/bootstrap.php
+++ b/app/config/bootstrap.php
@@ -5,12 +5,12 @@ $root = dirname(dirname(__DIR__));
 $config = array(
     /* Required */
 
-    // The directory where PEAR is located
-    'pear_path'      => '/usr/share/pear',
+    // The directory where Composer vendor is located (the one that phpunit was required into)
+    'composer_vendor_path' => $root . '/../vendor',
 
     // The directories where the tests reside
     'test_directories' => array(
-        "{$root}/app/test"
+        "{$root}/app/test",
     ),
 
 
@@ -63,7 +63,10 @@ $config = array(
     //
     // In order for VPU to function correctly, the configuration files must
     // contain a JSON listener (see the README for more information)
-    'xml_configuration_files' => array(),
+    'xml_configuration_files' => array(
+	    
+	    
+    ),
     //'xml_configuration_files' => array(
     //    "{$root}/app/config/phpunit.xml"
     //),
@@ -71,17 +74,19 @@ $config = array(
     // Paths to any necessary bootstraps
     'bootstraps' => array(
         // '/path/to/bootstrap.php'
+        
     )
 );
 
 set_include_path(
     get_include_path()
     . PATH_SEPARATOR . $root
-    . PATH_SEPARATOR . $config['pear_path']
+    . PATH_SEPARATOR . $config['composer_vendor_path']
+	. PATH_SEPARATOR . $config['composer_vendor_path'] . '/phpunit/phpunit/src'
 );
 
-require_once 'PHPUnit/Autoload.php';
-require_once 'PHPUnit/Util/Log/JSON.php';
+require_once 'autoload.php';
+require_once 'Util/Log/JSON.php';
 
 spl_autoload_register(function($class) use ($root) {
     $class = str_replace('\\', '/', $class);

--- a/app/controller/FileList.php
+++ b/app/controller/FileList.php
@@ -17,12 +17,16 @@ class FileList extends \app\core\Controller {
 
         $test_directories = \app\lib\Library::retrieve('test_directories');
         $valid_dir = false;
-        foreach ( $test_directories as $test_directory ) {
+        $group_name = '';
+        foreach ( $test_directories as $key => $test_directory ) {
             if ( strpos($dir, realpath($test_directory)) === 0 ) {
+	            $group_name = $key;
                 $valid_dir = true;
                 break;
             }
         }
+        
+        //echo 'here';
 
         if ( !$valid_dir ) {
             return array();
@@ -63,7 +67,7 @@ class FileList extends \app\core\Controller {
             }
         }
 
-        return array_merge($final_dirs, $final_files);
+        return array('name' => $group_name, 'results' => array_merge($final_dirs, $final_files));
     }
 
 }

--- a/app/controller/Home.php
+++ b/app/controller/Home.php
@@ -43,7 +43,7 @@ class Home extends \app\core\Controller {
                 return str_replace('\\', '/', realpath($path));
             };
             $test_directories = json_encode(array_map(
-                $normalize_path, \app\lib\Library::retrieve('test_directories')
+                $normalize_path, array_values(\app\lib\Library::retrieve('test_directories'))
             ));
 
             $suites = array();

--- a/app/lib/VPU.php
+++ b/app/lib/VPU.php
@@ -278,7 +278,7 @@ class VPU {
             print_r(array_slice($stack, 0, -2));
         }
         $trace = trim(ob_get_contents());
-        ob_end_clean();
+        if (ob_get_length()) ob_end_clean();
 
         return $trace;
     }
@@ -428,7 +428,7 @@ class VPU {
         }
 
         $result = new \PHPUnit_Framework_TestResult();
-        $result->addListener(new \PHPUnit_Util_Log_JSON());
+        $result->addListener(new \PHPUnit_Util_Log_JSON("/tmp/res.json"));
 
         // We need to temporarily turn off html_errors to ensure correct
         // parsing of test debug output
@@ -437,8 +437,9 @@ class VPU {
 
         ob_start();
         $suite->run($result);
-        $results = ob_get_contents();
-        ob_end_clean();
+        //$results = ob_get_contents();
+        $results = file_get_contents("/tmp/res.json");
+        if (ob_get_length()) ob_end_clean();
 
         ini_set('html_errors', $html_errors);
         return $results;
@@ -493,7 +494,7 @@ class VPU {
         ob_start();
         $command->run(array('--configuration', $xml_config, '--stderr'), false);
         $results = ob_get_contents();
-        ob_end_clean();
+        if (ob_get_length()) ob_end_clean();
 
         ini_set('html_errors', $html_errors);
 

--- a/app/public/js/jqueryFileSelector.js
+++ b/app/public/js/jqueryFileSelector.js
@@ -12,29 +12,40 @@
 
       return this.each(function() {
 
-        function buildTree($fileSelector, dir, isActive) {
+        function buildTree($fileSelector, dir, isActive, isSubdir) {
           $.get(options.serverEndpoint, {dir: dir}, function(response) {
-            var classAttr = ( $.inArray(dir, options.roots) ) ? " nav" : '',
-                html = "<ul class='nav-list" + classAttr + "' " +
-                  "style='display: none;'>";
-
             response = $.parseJSON(response);
-
-            $.each(response, function(index, file) {
-              var icon = ( file.type == 'directory' )
-                ? 'icon-folder-close'
-                : 'icon-file';
-              var classAttr = ( isActive ) ? ' active' : '';
-
-              html += "<li class='" + file.type + classAttr + "'>" +
-                        "<a href='#' data-path='" + file.path + "'>" +
-                          "<i class='" + icon + "'></i>" +
-                          file.name +
-                        '</a>' +
-                      '</li>';
-            });
+            var classAttr = ( $.inArray(dir, options.roots) ) ? " nav" : '',
+                html = "<ul class='nav-list"  + classAttr + "' " +
+                  "style='display: none;'>";
+                 
+            if(!isSubdir){
+				html += "<li class='directory'>" +
+                    "<a href='#' data-path='" + decodeURIComponent(dir) + "'>" +
+                      "<i class='icon-folder-close'></i>" +
+                      response.name +
+                    '</a>' +
+                  '</li>';
+            }else{           
+	            $.each(response.results, function(index, file) {
+	              var icon = ( file.type == 'directory' )
+	                ? 'icon-folder-close'
+	                : 'icon-file';
+	              var classAttr = ( isActive ) ? ' active' : '';
+	
+	              html += "<li class='" + file.type + classAttr + "'>" +
+	                        "<a href='#' data-path='" + file.path + "'>" +
+	                          "<i class='" + icon + "'></i>" +
+	                          file.name +
+	                        '</a>' +
+	                      '</li>';
+	            });
+            }
 
             html += '</ul>';
+            
+
+            
             var $ul = $(html);
             $fileSelector.append($ul);
 
@@ -49,7 +60,7 @@
         }
 
         function bindTree($fileSelector) {
-          $fileSelector.find('li a').bind('click', function(event) {
+          $fileSelector.find(' li a').bind('click', function(event) {
             var $this = $(this),
                 $parent = $this.parent(),
                 $children = $this.children(),
@@ -69,7 +80,8 @@
                   buildTree(
                     $parent,
                     encodeURIComponent($this.attr('data-path')),
-                    $parent.hasClass('active')
+                    $parent.hasClass('active'),
+                    true
                   );
                   $children.removeClass().addClass('icon-folder-open');
                 } else {
@@ -100,6 +112,7 @@
         }
 
         var length = options.roots.length;
+        console.log(options.roots);
         var $self = $(this);
         for ( var i = 0; i < length; i++ ) {
           buildTree($self, encodeURIComponent(options.roots[i]));


### PR DESCRIPTION
I updated this so this works with a composer install of PEAR. Since the PEAR install of PHPUnit reached End of Life on Dec 1, 2014 (source: https://github.com/sebastianbergmann/phpunit/wiki/End-of-Life-for-PEAR-Installation-Method), it is no longer possible to install PHPUnit via PEAR, thus the change.

I edited the documentation to reflect the new install method, and also took the liberty of adding a how to use with Laravel section.

Beyond that since I have a couple different projects running with different test directories and I wanted to use a single install of VisualPHPUnit, I also added grouping for test_directories with a keyed name for these to make it easier to select the specific test directory group. This was done in the last commit and could be dropped while still including the changes to make it work with composer.